### PR TITLE
Fix CVE-2017-8825

### DIFF
--- a/src/low-level/imf/mailimf.c
+++ b/src/low-level/imf/mailimf.c
@@ -3029,6 +3029,7 @@ static int mailimf_group_parse(const char * message, size_t length,
   struct mailimf_group * group;
   int r;
   int res;
+  clist * list;
 
   cur_token = * indx;
 
@@ -3054,6 +3055,17 @@ static int mailimf_group_parse(const char * message, size_t length,
     r = mailimf_cfws_parse(message, length, &cur_token);
     if ((r != MAILIMF_NO_ERROR) && (r != MAILIMF_ERROR_PARSE)) {
       res = r;
+      goto free_display_name;
+    }
+    list = clist_new();
+    if (list == NULL) {
+      res = MAILIMF_ERROR_MEMORY;
+      goto free_display_name;
+    }
+    mailbox_list = mailimf_mailbox_list_new(list);
+    if (mailbox_list == NULL) {
+      res = MAILIMF_ERROR_MEMORY;
+      clist_free(list);
       goto free_display_name;
     }
     break;


### PR DESCRIPTION
This is a backport of upstreams 1fe8fbc032 that fixes a NULL deref in
the MIME handling routines.

CVE: https://nvd.nist.gov/vuln/detail/CVE-2017-8825
Upstream issue: https://github.com/dinhviethoa/libetpan/issues/274