### PR TITLE
libetpan with Xcode 12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -562,7 +562,6 @@ if test "x$enable_ipv6" != "xno"; then
     AC_DEFINE(HAVE_IPV6, 1, [Define to enable IPv6 support.])
 
     dnl check for getaddrinfo and freeaddrinfo function presence
-  CFLAGS="$CFLAGS -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
     for func in "getaddrinfo" "freeaddrinfo"; do
       AC_MSG_CHECKING([for $func])
       AC_TRY_LINK([#include <netdb.h> ],

--- a/configure.ac
+++ b/configure.ac
@@ -562,11 +562,13 @@ if test "x$enable_ipv6" != "xno"; then
     AC_DEFINE(HAVE_IPV6, 1, [Define to enable IPv6 support.])
 
     dnl check for getaddrinfo and freeaddrinfo function presence
+  CFLAGS="$CFLAGS -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
     for func in "getaddrinfo" "freeaddrinfo"; do
       AC_MSG_CHECKING([for $func])
-      AC_TRY_LINK([], [$func();], 
-                      [func_present=yes], 
-                      [func_present=no])
+      AC_TRY_LINK([#include <netdb.h> ],
+                  [$func;],
+                  [func_present=yes],
+                  [func_present=no])
       AC_MSG_RESULT($func_present)
 
       if test "x$func_present" = "xno"; then


### PR DESCRIPTION
Using Xcode 12, an error appeared when trying to configure the project:

`configure: error: getaddrinfo function required for IPv6 support`

In order to fix that, we had to add the include file in AC_TRY_LINK where the getaddrinfo was checked.